### PR TITLE
Add README.md with GitHub Pages link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# xDuinoRails-PAWN-scripting
+
+Create a scriptable behaviour of the LED PIN on a Seeed RP2040 with PAWN.
+
+## Web Compiler
+
+You can use the online Pawn compiler and Blockly editor here:
+[https://chatelao.github.io/xDuinoRails-PAWN-scripting/](https://chatelao.github.io/xDuinoRails-PAWN-scripting/)
+
+## Documentation
+
+- [GEMINI.md](GEMINI.md): Project goals and structure.
+- [HOWTO_USE.md](HOWTO_USE.md): How to install the firmware and run Pawn scripts.
+- [HOWTO_BUILD.md](HOWTO_BUILD.md): How to build the firmware from source.
+
+## Project Structure
+
+- `/src`: The C source code for the RP2040 firmware.
+- `/web`: The web-based Pawn compiler and editor.
+- `/scripts`: Example Pawn scripts.
+- `/tests`: Playwright and Renode tests.


### PR DESCRIPTION
This PR adds a README.md file to the repository. The README includes a link to the project's GitHub Pages site, where the online Pawn compiler and Blockly editor are hosted. It also provides a brief overview of the project and links to the existing documentation files (GEMINI.md, HOWTO_USE.md, and HOWTO_BUILD.md).

Fixes #22

---
*PR created automatically by Jules for task [1216243196799744527](https://jules.google.com/task/1216243196799744527) started by @chatelao*