### PR TITLE
Add link to Pawn reference manual in HOWTO_USE.md

### DIFF
--- a/HOWTO_USE.md
+++ b/HOWTO_USE.md
@@ -17,6 +17,10 @@ To compile a Pawn script (e.g., `blink.p`), use the `pawncc` compiler:
 pawncc blink.p -o blink.amx
 ```
 
+### Documentation
+
+For a comprehensive guide to the Pawn language, refer to the official [Pawn Language Guide](https://codeberg.org/compuphase/pawn/raw/branch/main/doc/Pawn_Language_Guide.pdf).
+
 ### Example script (blink.p)
 
 ```pawn


### PR DESCRIPTION
This change adds a new "Documentation" section to the `HOWTO_USE.md` file, providing a direct link to the official Pawn Language Guide PDF hosted on Codeberg. This helps users find the language reference more easily.

Key changes:
- Modified `HOWTO_USE.md` to include a link to the Pawn Language Guide.
- Verified the link's accessibility using `curl`.
- Ran existing Playwright tests to ensure no regressions.

Fixes #24

---
*PR created automatically by Jules for task [7265559033971564076](https://jules.google.com/task/7265559033971564076) started by @chatelao*