### PR TITLE
Bidirectional Blockly-Code synchronization and persistence

### DIFF
--- a/tests/blockly.spec.ts
+++ b/tests/blockly.spec.ts
@@ -68,4 +68,100 @@ test.describe('Blockly Integration', () => {
     await expect(consoleArea).toContainText('Compiler returned: 0', { timeout: 10000 });
     await expect(consoleArea).toContainText('Success! .amx file generated.');
   });
+
+  test('should keep logic when switching from blockly to code', async ({ page }) => {
+    const toggleBtn = page.locator('#toggle-editor');
+    const editor = page.locator('#editor');
+
+    // Switch to Blockly mode
+    await toggleBtn.click();
+
+    // Add a block
+    await page.evaluate(() => {
+        // @ts-ignore
+        const ws = Blockly.getMainWorkspace();
+        ws.clear();
+        // @ts-ignore
+        const mainBlock = ws.newBlock('pawn_main');
+        mainBlock.initSvg();
+        mainBlock.render();
+
+        // @ts-ignore
+        const ledBlock = ws.newBlock('pawn_set_led');
+        ledBlock.setFieldValue('1', 'STATUS');
+        ledBlock.initSvg();
+        ledBlock.render();
+
+        const connection = mainBlock.getInput('STACK').connection;
+        connection.connect(ledBlock.previousConnection);
+    });
+
+    // Switch back to Code
+    await toggleBtn.click();
+
+    // Verify editor has the code
+    const code = await editor.inputValue();
+    expect(code).toContain('main() {');
+    expect(code).toContain('set_led(1);');
+  });
+
+  test('should ask for confirmation if code is modified and switching to blocks', async ({ page }) => {
+    const toggleBtn = page.locator('#toggle-editor');
+    const editor = page.locator('#editor');
+
+    // 1. Generate code from blocks first to set lastGeneratedCode
+    await toggleBtn.click(); // Switch to Blocks
+    await toggleBtn.click(); // Switch to Code (sets lastGeneratedCode)
+
+    // 2. Modify code
+    await editor.fill('main() { set_led(0); }');
+
+    // 3. Try to switch back to Blocks
+    page.once('dialog', async dialog => {
+      expect(dialog.message()).toContain('manual changes');
+      await dialog.accept();
+    });
+
+    await toggleBtn.click();
+
+    // Verify we are in blockly mode
+    await expect(page.locator('#blockly-container')).toBeVisible();
+
+    // Verify blocks were generated from the modified code
+    const blockCount = await page.evaluate(() => {
+        // @ts-ignore
+        return Blockly.getMainWorkspace().getAllBlocks(false).length;
+    });
+    expect(blockCount).toBeGreaterThan(0);
+  });
+
+  test('should generate blocks from code', async ({ page }) => {
+    const toggleBtn = page.locator('#toggle-editor');
+    const editor = page.locator('#editor');
+
+    const testCode = `
+main() {
+    set_led(1);
+    delay(500);
+    while (true) {
+        set_led(0);
+    }
+}
+`;
+    await editor.fill(testCode);
+
+    await toggleBtn.click(); // Switch to Blocks
+
+    // Verify blocks were created
+    const blocks = await page.evaluate(() => {
+        // @ts-ignore
+        const ws = Blockly.getMainWorkspace();
+        return ws.getAllBlocks(false).map(b => b.type);
+    });
+
+    expect(blocks).toContain('pawn_main');
+    expect(blocks).toContain('pawn_set_led');
+    expect(blocks).toContain('pawn_delay');
+    expect(blocks).toContain('controls_whileUntil');
+  });
 });

--- a/web/app.js
+++ b/web/app.js
@@ -83,6 +83,68 @@ PawnGenerator.forBlock['logic_boolean'] = function(block) {
   return [code, PawnGenerator.PRECEDENCE.ATOMIC];
 };
 
+PawnGenerator.forBlock['controls_if'] = function(block) {
+  let n = 0;
+  let code = '';
+  do {
+    const conditionCode = PawnGenerator.valueToCode(block, 'IF' + n, PawnGenerator.PRECEDENCE.ATOMIC) || 'false';
+    const branchCode = PawnGenerator.statementToCode(block, 'DO' + n);
+    code += (n === 0 ? 'if (' : ' else if (') + conditionCode + ') {\n' + branchCode + '}';
+    n++;
+  } while (block.getInput('IF' + n));
+
+  if (block.getInput('ELSE')) {
+    const branchCode = PawnGenerator.statementToCode(block, 'ELSE');
+    code += ' else {\n' + branchCode + '}';
+  }
+  return code + '\n';
+};
+
+PawnGenerator.forBlock['logic_compare'] = function(block) {
+  const OPERATORS = {
+    'EQ': '==',
+    'NEQ': '!=',
+    'LT': '<',
+    'LTE': '<=',
+    'GT': '>',
+    'GTE': '>='
+  };
+  const operator = OPERATORS[block.getFieldValue('OP')];
+  const argument0 = PawnGenerator.valueToCode(block, 'A', PawnGenerator.PRECEDENCE.ATOMIC) || '0';
+  const argument1 = PawnGenerator.valueToCode(block, 'B', PawnGenerator.PRECEDENCE.ATOMIC) || '0';
+  const code = argument0 + ' ' + operator + ' ' + argument1;
+  return [code, PawnGenerator.PRECEDENCE.ATOMIC];
+};
+
+PawnGenerator.forBlock['logic_operation'] = function(block) {
+  const operator = (block.getFieldValue('OP') == 'AND') ? '&&' : '||';
+  const argument0 = PawnGenerator.valueToCode(block, 'A', PawnGenerator.PRECEDENCE.ATOMIC) || 'false';
+  const argument1 = PawnGenerator.valueToCode(block, 'B', PawnGenerator.PRECEDENCE.ATOMIC) || 'false';
+  const code = '(' + argument0 + ' ' + operator + ' ' + argument1 + ')';
+  return [code, PawnGenerator.PRECEDENCE.ATOMIC];
+};
+
+PawnGenerator.forBlock['math_arithmetic'] = function(block) {
+  const OPERATORS = {
+    'ADD': [' + ', PawnGenerator.PRECEDENCE.ATOMIC],
+    'MINUS': [' - ', PawnGenerator.PRECEDENCE.ATOMIC],
+    'MULTIPLY': [' * ', PawnGenerator.PRECEDENCE.ATOMIC],
+    'DIVIDE': [' / ', PawnGenerator.PRECEDENCE.ATOMIC],
+    'POWER': [null, PawnGenerator.PRECEDENCE.ATOMIC]  // Pawn doesn't have **
+  };
+  const tuple = OPERATORS[block.getFieldValue('OP')];
+  const operator = tuple[0];
+  const argument0 = PawnGenerator.valueToCode(block, 'A', PawnGenerator.PRECEDENCE.ATOMIC) || '0';
+  const argument1 = PawnGenerator.valueToCode(block, 'B', PawnGenerator.PRECEDENCE.ATOMIC) || '0';
+  let code;
+  if (!operator) {
+    code = 'pow(' + argument0 + ', ' + argument1 + ')';
+  } else {
+    code = argument0 + operator + argument1;
+  }
+  return [code, PawnGenerator.PRECEDENCE.ATOMIC];
+};
+
 PawnGenerator.scrub_ = function(block, code, opt_thisOnly) {
   const nextBlock = block.getNextBlock();
   const nextCode = opt_thisOnly ? '' : PawnGenerator.blockToCode(nextBlock);
@@ -101,13 +163,168 @@ const consoleArea = document.getElementById('console');
 
 let isBlocklyMode = false;
 let workspace;
+let lastGeneratedCode = '';
+
+function generatePawnCode() {
+    let generatedCode = '';
+    try {
+        generatedCode = PawnGenerator.workspaceToCode(workspace);
+    } catch (e) {
+        log('Error generating code: ' + e);
+    }
+    return 'native set_led(status);\n' +
+           'native delay(ms);\n\n' +
+           generatedCode;
+}
+
+function generateBlocksFromCode(code) {
+    if (!workspace) return;
+    workspace.clear();
+
+    // Remove comments and native declarations
+    code = code.replace(/\/\/.*$/gm, '');
+    code = code.replace(/native\s+\w+\([^)]*\);/g, '');
+
+    // Basic regex-based parser for the most common blocks
+    const mainMatch = code.match(/main\s*\(\s*\)\s*\{([\s\S]*)\}/);
+    if (mainMatch) {
+        const mainBlock = workspace.newBlock('pawn_main');
+        mainBlock.initSvg();
+        mainBlock.render();
+
+        const body = mainMatch[1].trim();
+        parseStatements(body, mainBlock.getInput('STACK').connection);
+    }
+}
+
+function parseStatements(code, connection) {
+    let currentConnection = connection;
+    let remaining = code.trim();
+
+    while (remaining.length > 0) {
+        let match;
+        // set_led(status)
+        if (match = remaining.match(/^set_led\((\d+)\);/)) {
+            const block = workspace.newBlock('pawn_set_led');
+            block.setFieldValue(match[1], 'STATUS');
+            block.initSvg();
+            block.render();
+            currentConnection.connect(block.previousConnection);
+            currentConnection = block.nextConnection;
+            remaining = remaining.substring(match[0].length).trim();
+        }
+        // delay(ms)
+        else if (match = remaining.match(/^delay\((\d+)\);/)) {
+            const block = workspace.newBlock('pawn_delay');
+            const numBlock = workspace.newBlock('math_number');
+            numBlock.setFieldValue(match[1], 'NUM');
+            numBlock.initSvg();
+            numBlock.render();
+            block.getInput('MS').connection.connect(numBlock.outputConnection);
+            block.initSvg();
+            block.render();
+            currentConnection.connect(block.previousConnection);
+            currentConnection = block.nextConnection;
+            remaining = remaining.substring(match[0].length).trim();
+        }
+        // while (bool) { ... }
+        else if (match = remaining.match(/^while\s*\(([^)]+)\)\s*\{/)) {
+            const block = workspace.newBlock('controls_whileUntil');
+            const condition = match[1].trim();
+            // Handle true/false
+            if (condition === 'true' || condition === 'false') {
+                const boolBlock = workspace.newBlock('logic_boolean');
+                boolBlock.setFieldValue(condition.toUpperCase(), 'BOOL');
+                boolBlock.initSvg();
+                boolBlock.render();
+                block.getInput('BOOL').connection.connect(boolBlock.outputConnection);
+            }
+
+            // Find closing brace
+            let braceCount = 1;
+            let i = match[0].length;
+            let start = i;
+            while (braceCount > 0 && i < remaining.length) {
+                if (remaining[i] === '{') braceCount++;
+                if (remaining[i] === '}') braceCount--;
+                i++;
+            }
+            const innerBody = remaining.substring(start, i - 1).trim();
+            parseStatements(innerBody, block.getInput('DO').connection);
+
+            block.initSvg();
+            block.render();
+            currentConnection.connect(block.previousConnection);
+            currentConnection = block.nextConnection;
+            remaining = remaining.substring(i).trim();
+        }
+        // for (new i = 0; i < repeats; i++) { ... }
+        else if (match = remaining.match(/^for\s*\(new\s+i\s*=\s*0;\s*i\s*<\s*(\d+);\s*i\+\+\)\s*\{/)) {
+            const block = workspace.newBlock('controls_repeat_ext');
+            const repeats = match[1];
+            const numBlock = workspace.newBlock('math_number');
+            numBlock.setFieldValue(repeats, 'NUM');
+            numBlock.initSvg();
+            numBlock.render();
+            block.getInput('TIMES').connection.connect(numBlock.outputConnection);
+
+            // Find closing brace
+            let braceCount = 1;
+            let i = match[0].length;
+            let start = i;
+            while (braceCount > 0 && i < remaining.length) {
+                if (remaining[i] === '{') braceCount++;
+                if (remaining[i] === '}') braceCount--;
+                i++;
+            }
+            const innerBody = remaining.substring(start, i - 1).trim();
+            parseStatements(innerBody, block.getInput('DO').connection);
+
+            block.initSvg();
+            block.render();
+            currentConnection.connect(block.previousConnection);
+            currentConnection = block.nextConnection;
+            remaining = remaining.substring(i).trim();
+        }
+        else {
+            // Skip unknown statement until semicolon or end
+            const nextSemi = remaining.indexOf(';');
+            if (nextSemi !== -1) {
+                remaining = remaining.substring(nextSemi + 1).trim();
+            } else {
+                remaining = "";
+            }
+        }
+    }
+}
 
 toggleBtn.addEventListener('click', () => {
-    isBlocklyMode = !isBlocklyMode;
     if (isBlocklyMode) {
+        // Switch to Code
+        const code = generatePawnCode();
+        editor.value = code;
+        lastGeneratedCode = code;
+
+        isBlocklyMode = false;
+        editorContainer.style.display = 'flex';
+        blocklyContainer.style.display = 'none';
+        toggleBtn.textContent = 'Switch to Blocks';
+    } else {
+        // Switch to Blocks
+        const currentCode = editor.value;
+        const needsConfirmation = lastGeneratedCode !== '' && currentCode !== lastGeneratedCode;
+
+        if (needsConfirmation) {
+            if (!confirm('You have made manual changes to the code. Switching to blocks will attempt to re-parse your code, and some manual changes might be lost. Continue?')) {
+                return;
+            }
+        }
+
+        isBlocklyMode = true;
         editorContainer.style.display = 'none';
         blocklyContainer.style.display = 'flex';
         toggleBtn.textContent = 'Switch to Code';
+
         if (!workspace) {
             workspace = Blockly.inject('blockly-div', {
                 toolbox: document.getElementById('toolbox'),
@@ -117,10 +334,10 @@ toggleBtn.addEventListener('click', () => {
         } else {
             Blockly.svgResize(workspace);
         }
-    } else {
-        editorContainer.style.display = 'flex';
-        blocklyContainer.style.display = 'none';
-        toggleBtn.textContent = 'Switch to Blocks';
+
+        if (needsConfirmation || lastGeneratedCode === '') {
+            generateBlocksFromCode(currentCode);
+        }
     }
 });
 
@@ -155,15 +372,8 @@ compileBtn.addEventListener('click', async () => {
 
     let code = editor.value;
     if (isBlocklyMode) {
-        let generatedCode = '';
-        try {
-            generatedCode = PawnGenerator.workspaceToCode(workspace);
-        } catch (e) {
-            log('Error generating code: ' + e);
-        }
-        code = 'native set_led(status);\n' +
-               'native delay(ms);\n\n' +
-               generatedCode;
+        code = generatePawnCode();
+        lastGeneratedCode = code;
         log('Generated Code:\n' + code);
     }
 


### PR DESCRIPTION
This PR enhances the PAWN Online Compiler WebUI by ensuring that the logic is preserved when switching between the Blockly visual editor and the Pawn source code editor.

Key features:
- **Blocks to Code**: Enhanced `PawnGenerator` now supports `controls_if`, `logic_compare`, `logic_operation`, and `math_arithmetic`.
- **Code to Blocks**: A new `generateBlocksFromCode` parser attempts to reconstruct the Blockly workspace from Pawn code, supporting `main()`, `set_led()`, `delay()`, `while` loops, and `for` loops.
- **Data Loss Prevention**: The application tracks manual edits in the code editor. If a user attempts to switch back to Blockly after making manual changes, a confirmation dialog appears to warn about potential data loss.
- **Firmware Ready**: Generated code now automatically includes the necessary `native` declarations for `set_led` and `delay`.

Verification:
- Added 3 new Playwright tests in `tests/blockly.spec.ts` covering logic persistence, confirmation dialogs, and code-to-blocks conversion.
- All 8 tests passed successfully.
- Visual verification was performed via screenshots using a custom Playwright script.

Fixes #23

---
*PR created automatically by Jules for task [3709837870905536672](https://jules.google.com/task/3709837870905536672) started by @chatelao*