### PR TITLE
Rename PAWN Online Compiler to XDRscript

### DIFF
--- a/tests/compiler.spec.ts
+++ b/tests/compiler.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('PAWN Online Compiler', () => {
+test.describe('XDRscript', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
   });
 
   test('should load the page and initialize the compiler', async ({ page }) => {
-    await expect(page).toHaveTitle(/PAWN Online Compiler/);
+    await expect(page).toHaveTitle(/XDRscript/);
     const compileBtn = page.locator('#compile-btn');
     await expect(compileBtn).toBeEnabled({ timeout: 10000 });
     await expect(compileBtn).toHaveText('Compile');

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>PAWN Online Compiler</title>
+    <title>XDRscript</title>
     <style>
         body { font-family: sans-serif; display: flex; flex-direction: column; height: 100vh; margin: 0; }
         header { background: #333; color: white; padding: 1rem; }
@@ -23,7 +23,7 @@
 </head>
 <body>
     <header>
-        <h1>PAWN Online Compiler</h1>
+        <h1>XDRscript</h1>
     </header>
     <div class="toolbar">
         <button id="compile-btn" disabled>Loading Compiler...</button>


### PR DESCRIPTION
Renamed the application from "PAWN Online Compiler" to "XDRscript" in both the web UI and the test suite. Verified the changes by running automated tests and visual inspection of a screenshot.

Fixes #33

---
*PR created automatically by Jules for task [15808695792578457797](https://jules.google.com/task/15808695792578457797) started by @chatelao*