### PR TITLE
Automate editor synchronization and remove manual copy buttons

### DIFF
--- a/tests/blockly.spec.ts
+++ b/tests/blockly.spec.ts
@@ -230,15 +230,15 @@ main() {
     expect(textValue).toBe('Revised Print');
   });
 
-  test('should copy between editors using buttons', async ({ page }) => {
+  test('should synchronize between editors when switching', async ({ page }) => {
+    const toggleBtn = page.locator('#toggle-editor');
     const editor = page.locator('#editor');
-    const copyToCodeBtn = page.locator('#copy-to-code');
-    const copyToBlocksBtn = page.locator('#copy-to-blocks');
 
-    // 1. Blockly -> Code
+    // 1. Blockly -> Code synchronization
+    await toggleBtn.click(); // Switch to Blocks
     await page.evaluate(() => {
         // @ts-ignore
-        const ws = Blockly.getMainWorkspace() || Blockly.inject('blockly-div', { toolbox: document.getElementById('toolbox') });
+        const ws = Blockly.getMainWorkspace();
         ws.clear();
         // @ts-ignore
         const mainBlock = ws.newBlock('pawn_main');
@@ -252,17 +252,21 @@ main() {
         mainBlock.getInput('STACK').connection.connect(ledBlock.previousConnection);
     });
 
-    await copyToCodeBtn.click();
+    await toggleBtn.click(); // Switch to Code
     let code = await editor.inputValue();
     expect(code).toContain('set_led(1);');
 
-    // 2. Code -> Blockly
+    // 2. Code -> Blockly synchronization
     await editor.fill('main() { set_led(0); }');
-    await copyToBlocksBtn.click();
 
-    // Wait a bit for blocks to be generated
-    await page.waitForTimeout(500);
+    // Switch to Blocks (should trigger sync)
+    // First, it might ask for confirmation because editor.value != lastGeneratedCode
+    page.once('dialog', async dialog => {
+      await dialog.accept();
+    });
+    await toggleBtn.click();
 
+    // Verify blocks were updated
     const ledStatus = await page.evaluate(() => {
         // @ts-ignore
         const ws = Blockly.getMainWorkspace();

--- a/web/app.js
+++ b/web/app.js
@@ -181,8 +181,6 @@ PawnGenerator.scrub_ = function(block, code, opt_thisOnly) {
 
 const compileBtn = document.getElementById('compile-btn');
 const loadBtn = document.getElementById('load-btn');
-const copyToCodeBtn = document.getElementById('copy-to-code');
-const copyToBlocksBtn = document.getElementById('copy-to-blocks');
 const toggleBtn = document.getElementById('toggle-editor');
 const fileInput = document.getElementById('file-input');
 const downloadLink = document.getElementById('download-link');
@@ -487,18 +485,6 @@ toggleBtn.addEventListener('click', () => {
     }
 });
 
-copyToCodeBtn.addEventListener('click', () => {
-    const code = generatePawnCode();
-    editor.value = code;
-    lastGeneratedCode = code;
-    log('Copied Blockly to Code.');
-});
-
-copyToBlocksBtn.addEventListener('click', () => {
-    const currentCode = editor.value;
-    generateBlocksFromCode(currentCode);
-    log('Copied Code to Blockly.');
-});
 
 function log(text) {
     consoleArea.textContent += text + '\n';

--- a/web/index.html
+++ b/web/index.html
@@ -28,8 +28,6 @@
     <div class="toolbar">
         <button id="compile-btn" disabled>Loading Compiler...</button>
         <button id="load-btn">Load Script (.pwn)</button>
-        <button id="copy-to-code">Copy to Code</button>
-        <button id="copy-to-blocks">Copy to Blockly</button>
         <button id="toggle-editor" class="toggle-btn">Switch to Blocks</button>
         <input type="file" id="file-input" accept=".pwn,.p,.inc" style="display: none;">
         <a id="download-link" href="#" download="script.amx">Download .amx</a>


### PR DESCRIPTION
This PR removes the manual "Copy to Code" and "Copy to Blockly" buttons from the toolbar, as their functionality is already implicitly handled by the "Switch to Blocks/Code" toggle button. The code synchronization logic is now fully encapsulated within the switching flow, providing a cleaner UI and a more intuitive user experience. Tests have been updated to ensure that switching between modes correctly triggers the appropriate synchronization (parsing PAWN code into Blockly blocks and generating PAWN code from Blockly blocks).

Fixes #34

---
*PR created automatically by Jules for task [15908727744218356556](https://jules.google.com/task/15908727744218356556) started by @chatelao*