### PR TITLE
Add speed and direction native functions

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -41,10 +41,26 @@ static cell AMX_NATIVE_CALL n_print(AMX *amx, const cell *params) {
     return 0;
 }
 
+// Native function: speed()
+static cell AMX_NATIVE_CALL n_speed(AMX *amx, const cell *params) {
+    (void)amx;
+    (void)params;
+    return 55;
+}
+
+// Native function: direction()
+static cell AMX_NATIVE_CALL n_direction(AMX *amx, const cell *params) {
+    (void)amx;
+    (void)params;
+    return 1; // Forward
+}
+
 static const AMX_NATIVE_INFO led_natives[] = {
-    { "set_led", n_set_led },
-    { "delay",   n_delay },
-    { "print",   n_print },
+    { "set_led",   n_set_led },
+    { "delay",     n_delay },
+    { "print",     n_print },
+    { "speed",     n_speed },
+    { "direction", n_direction },
     { NULL, NULL }
 };
 

--- a/web/app.js
+++ b/web/app.js
@@ -11,6 +11,28 @@ Blockly.Blocks['pawn_main'] = {
   }
 };
 
+Blockly.Blocks['pawn_speed'] = {
+  init: function() {
+    this.appendDummyInput()
+        .appendField("speed");
+    this.setOutput(true, "Number");
+    this.setColour(160);
+    this.setTooltip("Returns the current speed (fixed at 55)");
+    this.setHelpUrl("");
+  }
+};
+
+Blockly.Blocks['pawn_direction'] = {
+  init: function() {
+    this.appendDummyInput()
+        .appendField("direction");
+    this.setOutput(true, "Number");
+    this.setColour(160);
+    this.setTooltip("Returns the current direction (Forward)");
+    this.setHelpUrl("");
+  }
+};
+
 Blockly.Blocks['pawn_set_led'] = {
   init: function() {
     this.appendDummyInput()
@@ -77,6 +99,14 @@ PawnGenerator.forBlock['pawn_delay'] = function(block) {
 PawnGenerator.forBlock['pawn_print'] = function(block) {
   const text = PawnGenerator.valueToCode(block, 'TEXT', PawnGenerator.PRECEDENCE.ATOMIC) || '""';
   return 'print(' + text + ');\n';
+};
+
+PawnGenerator.forBlock['pawn_speed'] = function(block) {
+  return ['speed()', PawnGenerator.PRECEDENCE.ATOMIC];
+};
+
+PawnGenerator.forBlock['pawn_direction'] = function(block) {
+  return ['direction()', PawnGenerator.PRECEDENCE.ATOMIC];
 };
 
 PawnGenerator.forBlock['text'] = function(block) {
@@ -206,7 +236,11 @@ function generatePawnCode() {
         log('Error generating code: ' + e);
     }
     return 'native set_led(status);\n' +
-           'native delay(ms);\n\n' +
+           'native delay(ms);\n' +
+           'native speed();\n' +
+           'native direction();\n\n' +
+           'const FORWARD = 1;\n' +
+           'const BACKWARD = 0;\n\n' +
            generatedCode;
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -94,6 +94,8 @@ main() {
             <block type="pawn_main"></block>
             <block type="pawn_set_led"></block>
             <block type="pawn_delay"></block>
+            <block type="pawn_speed"></block>
+            <block type="pawn_direction"></block>
             <block type="pawn_print">
                 <value name="TEXT">
                     <shadow type="text">


### PR DESCRIPTION
I have implemented the requested native functions "speed" and "direction". 

Specifically:
1. **Firmware (C Code)**: Added `n_speed` returning a fixed value of 55 and `n_direction` returning 1 (Forward) in `src/main.c`, and registered them as PAWN natives.
2. **Web Interface (Blockly)**: Created new Blockly blocks for `speed` and `direction` in `web/app.js`.
3. **Code Generation**: Updated the PAWN code generator to automatically include `native speed();` and `native direction();` declarations, as well as `FORWARD` (1) and `BACKWARD` (0) constants for easier script writing.
4. **UI**: Added the new blocks to the "Pawn" category in the Blockly toolbox in `web/index.html`.

I verified these changes by running the existing test suite and performing a visual verification using Playwright to ensure the blocks generate the expected code and compile correctly.

Fixes #35

---
*PR created automatically by Jules for task [3672594255420085496](https://jules.google.com/task/3672594255420085496) started by @chatelao*