### PR TITLE
Add native CV function for random value generation

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -55,12 +55,20 @@ static cell AMX_NATIVE_CALL n_direction(AMX *amx, const cell *params) {
     return 1; // Forward
 }
 
+// Native function: CV(id)
+static cell AMX_NATIVE_CALL n_cv(AMX *amx, const cell *params) {
+    (void)amx;
+    (void)params;
+    return rand() % 256;
+}
+
 static const AMX_NATIVE_INFO led_natives[] = {
     { "set_led",   n_set_led },
     { "delay",     n_delay },
     { "print",     n_print },
     { "speed",     n_speed },
     { "direction", n_direction },
+    { "CV",        n_cv },
     { NULL, NULL }
 };
 
@@ -109,6 +117,7 @@ void run_script(void *program, size_t size) {
 
 int main() {
     stdio_init_all();
+    srand(time_us_64());
     gpio_init(LED_PIN);
     gpio_set_dir(LED_PIN, GPIO_OUT);
 

--- a/web/app.js
+++ b/web/app.js
@@ -33,6 +33,18 @@ Blockly.Blocks['pawn_direction'] = {
   }
 };
 
+Blockly.Blocks['pawn_cv'] = {
+  init: function() {
+    this.appendValueInput("ID")
+        .setCheck("Number")
+        .appendField("CV");
+    this.setOutput(true, "Number");
+    this.setColour(160);
+    this.setTooltip("Returns a random value (0-255) for the given CV ID");
+    this.setHelpUrl("");
+  }
+};
+
 Blockly.Blocks['pawn_set_led'] = {
   init: function() {
     this.appendDummyInput()
@@ -64,7 +76,7 @@ Blockly.Blocks['pawn_delay'] = {
 Blockly.Blocks['pawn_print'] = {
   init: function() {
     this.appendValueInput("TEXT")
-        .setCheck("String")
+        .setCheck(null)
         .appendField("print");
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
@@ -107,6 +119,11 @@ PawnGenerator.forBlock['pawn_speed'] = function(block) {
 
 PawnGenerator.forBlock['pawn_direction'] = function(block) {
   return ['direction()', PawnGenerator.PRECEDENCE.ATOMIC];
+};
+
+PawnGenerator.forBlock['pawn_cv'] = function(block) {
+  const id = PawnGenerator.valueToCode(block, 'ID', PawnGenerator.PRECEDENCE.ATOMIC) || '0';
+  return ['CV(' + id + ')', PawnGenerator.PRECEDENCE.ATOMIC];
 };
 
 PawnGenerator.forBlock['text'] = function(block) {
@@ -236,7 +253,8 @@ function generatePawnCode() {
     return 'native set_led(status);\n' +
            'native delay(ms);\n' +
            'native speed();\n' +
-           'native direction();\n\n' +
+           'native direction();\n' +
+           'native CV(id);\n\n' +
            'const FORWARD = 1;\n' +
            'const BACKWARD = 0;\n\n' +
            generatedCode;
@@ -282,6 +300,13 @@ function parseStatements(code, connection) {
             block.render();
             currentConnection.connect(block.previousConnection);
             currentConnection = block.nextConnection;
+            remaining = remaining.substring(match[0].length).trim();
+        }
+        // CV(id) - as a statement (though it's an expression)
+        else if (match = remaining.match(/^CV\((\d+)\);/)) {
+            // Technically CV(id); is valid but does nothing.
+            // We don't have a statement block for CV, it's an expression.
+            // If it appears as a statement, we just skip it for now or we could add a block.
             remaining = remaining.substring(match[0].length).trim();
         }
         // print("text")

--- a/web/index.html
+++ b/web/index.html
@@ -94,6 +94,13 @@ main() {
             <block type="pawn_delay"></block>
             <block type="pawn_speed"></block>
             <block type="pawn_direction"></block>
+            <block type="pawn_cv">
+                <value name="ID">
+                    <shadow type="math_number">
+                        <field name="NUM">0</field>
+                    </shadow>
+                </value>
+            </block>
             <block type="pawn_print">
                 <value name="TEXT">
                     <shadow type="text">


### PR DESCRIPTION
This change implements a new native function `CV(id)` in the Pawn runtime and adds a corresponding block to the Blockly-based web interface. The function returns a random value between 0 and 255, which can be used for randomized script behavior. The random number generator is seeded with the system time on startup. The web interface has been updated to include the new block in the toolbox and automatically handle the necessary `native` declaration.

Fixes #42

---
*PR created automatically by Jules for task [1173046335972803792](https://jules.google.com/task/1173046335972803792) started by @chatelao*