### PR TITLE
Remove loops from Blockly options

### DIFF
--- a/tests/blockly.spec.ts
+++ b/tests/blockly.spec.ts
@@ -149,9 +149,6 @@ test.describe('Blockly Integration', () => {
 main() {
     set_led(1);
     delay(500);
-    while (true) {
-        set_led(0);
-    }
 }
 `;
     await editor.fill(testCode);
@@ -168,7 +165,7 @@ main() {
     expect(blocks).toContain('pawn_main');
     expect(blocks).toContain('pawn_set_led');
     expect(blocks).toContain('pawn_delay');
-    expect(blocks).toContain('controls_whileUntil');
+    expect(blocks).not.toContain('controls_whileUntil');
   });
 
   test('should handle Print block bidirectionally', async ({ page }) => {

--- a/web/app.js
+++ b/web/app.js
@@ -119,18 +119,6 @@ PawnGenerator.forBlock['math_number'] = function(block) {
   return [code, PawnGenerator.PRECEDENCE.ATOMIC];
 };
 
-PawnGenerator.forBlock['controls_repeat_ext'] = function(block) {
-  const repeats = PawnGenerator.valueToCode(block, 'TIMES', PawnGenerator.PRECEDENCE.ATOMIC) || '0';
-  const branch = PawnGenerator.statementToCode(block, 'DO');
-  return 'for (new i = 0; i < ' + repeats + '; i++) {\n' + branch + '}\n';
-};
-
-PawnGenerator.forBlock['controls_whileUntil'] = function(block) {
-  const argument0 = PawnGenerator.valueToCode(block, 'BOOL', PawnGenerator.PRECEDENCE.ATOMIC) || 'false';
-  const branch = PawnGenerator.statementToCode(block, 'DO');
-  return 'while (' + argument0 + ') {\n' + branch + '}\n';
-};
-
 PawnGenerator.forBlock['logic_boolean'] = function(block) {
   const code = (block.getFieldValue('BOOL') == 'TRUE') ? 'true' : 'false';
   return [code, PawnGenerator.PRECEDENCE.ATOMIC];
@@ -311,65 +299,6 @@ function parseStatements(code, connection) {
             currentConnection.connect(block.previousConnection);
             currentConnection = block.nextConnection;
             remaining = remaining.substring(match[0].length).trim();
-        }
-        // while (bool) { ... }
-        else if (match = remaining.match(/^while\s*\(([^)]+)\)\s*\{/)) {
-            const block = workspace.newBlock('controls_whileUntil');
-            const condition = match[1].trim();
-            // Handle true/false
-            if (condition === 'true' || condition === 'false') {
-                const boolBlock = workspace.newBlock('logic_boolean');
-                boolBlock.setFieldValue(condition.toUpperCase(), 'BOOL');
-                boolBlock.initSvg();
-                boolBlock.render();
-                block.getInput('BOOL').connection.connect(boolBlock.outputConnection);
-            }
-
-            // Find closing brace
-            let braceCount = 1;
-            let i = match[0].length;
-            let start = i;
-            while (braceCount > 0 && i < remaining.length) {
-                if (remaining[i] === '{') braceCount++;
-                if (remaining[i] === '}') braceCount--;
-                i++;
-            }
-            const innerBody = remaining.substring(start, i - 1).trim();
-            parseStatements(innerBody, block.getInput('DO').connection);
-
-            block.initSvg();
-            block.render();
-            currentConnection.connect(block.previousConnection);
-            currentConnection = block.nextConnection;
-            remaining = remaining.substring(i).trim();
-        }
-        // for (new i = 0; i < repeats; i++) { ... }
-        else if (match = remaining.match(/^for\s*\(new\s+i\s*=\s*0;\s*i\s*<\s*(\d+);\s*i\+\+\)\s*\{/)) {
-            const block = workspace.newBlock('controls_repeat_ext');
-            const repeats = match[1];
-            const numBlock = workspace.newBlock('math_number');
-            numBlock.setFieldValue(repeats, 'NUM');
-            numBlock.initSvg();
-            numBlock.render();
-            block.getInput('TIMES').connection.connect(numBlock.outputConnection);
-
-            // Find closing brace
-            let braceCount = 1;
-            let i = match[0].length;
-            let start = i;
-            while (braceCount > 0 && i < remaining.length) {
-                if (remaining[i] === '{') braceCount++;
-                if (remaining[i] === '}') braceCount--;
-                i++;
-            }
-            const innerBody = remaining.substring(start, i - 1).trim();
-            parseStatements(innerBody, block.getInput('DO').connection);
-
-            block.initSvg();
-            block.render();
-            currentConnection.connect(block.previousConnection);
-            currentConnection = block.nextConnection;
-            remaining = remaining.substring(i).trim();
         }
         // if (cond) { ... } [else if (cond) { ... }] [else { ... }]
         else if (match = remaining.match(/^if\s*\(([^)]+)\)\s*\{/)) {

--- a/web/index.html
+++ b/web/index.html
@@ -111,16 +111,6 @@ main() {
             <block type="logic_operation"></block>
             <block type="logic_boolean"></block>
         </category>
-        <category name="Loops" colour="#5ba55b">
-            <block type="controls_repeat_ext">
-                <value name="TIMES">
-                    <shadow type="math_number">
-                        <field name="NUM">10</field>
-                    </shadow>
-                </value>
-            </block>
-            <block type="controls_whileUntil"></block>
-        </category>
         <category name="Math" colour="#5b67a5">
             <block type="math_number"></block>
             <block type="math_arithmetic"></block>


### PR DESCRIPTION
This change removes loop-related options from the Blockly visual editor to simplify the scripting interface. It involves UI changes (toolbox removal), generator changes, and parser updates to ensure consistency when switching between code and blocks. Existing tests have been updated to match the new behavior.

Fixes #43

---
*PR created automatically by Jules for task [7039699906932727934](https://jules.google.com/task/7039699906932727934) started by @chatelao*